### PR TITLE
[2022/06/13] 로그아웃 기능 추가, jwt token 저장 및 인가가 필요한 api 요청 헤더 추가

### DIFF
--- a/src/components/shared/header.jsx
+++ b/src/components/shared/header.jsx
@@ -11,16 +11,25 @@ import { AntDesign } from "@expo/vector-icons";
 import { UserAuth } from "../../context/AuthContext";
 
 function AppHeader({ navigation }) {
-  const { user } = UserAuth();
+  const { user, setUser, setIdToken } = UserAuth();
 
   const handleLogin = () => navigation.navigate("Login");
+  const handleLogout = () => {
+    setUser("");
+    setIdToken("");
+
+    navigation.navigate("Home");
+  };
 
   return (
     <View style={styles.container}>
       <TouchableOpacity style={styles.logo}>
         <AntDesign name="smileo" size={36} color="black" />
       </TouchableOpacity>
-      <Pressable style={styles.button} onPress={handleLogin}>
+      <Pressable
+        style={styles.button}
+        onPress={user ? handleLogout : handleLogin}
+      >
         <Text style={styles.text}>{user ? "로그아웃" : "로그인"}</Text>
       </Pressable>
     </View>

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -3,8 +3,8 @@ import { useContext, createContext, useState } from "react";
 const AuthContext = createContext();
 
 export function AuthContextProvider({ children }) {
-  const [user, setUser] = useState(null);
-  const [idToken, setIdToken] = useState(null);
+  const [user, setUser] = useState("");
+  const [idToken, setIdToken] = useState("");
 
   return (
     <AuthContext.Provider value={{ user, setUser, idToken, setIdToken }}>

--- a/src/screen/LoginScreen.jsx
+++ b/src/screen/LoginScreen.jsx
@@ -11,6 +11,7 @@ import { StatusBar } from "expo-status-bar";
 import * as Google from "expo-auth-session/providers/google";
 import * as WebBrowser from "expo-web-browser";
 import googleLoginButtonImage from "../../assets/google-login-button.png";
+import { UserAuth } from "../context/AuthContext";
 
 import ModalError from "../components/ModalError";
 
@@ -32,21 +33,23 @@ function LoginScreen({ navigation }) {
 
   const handleLogin = async (id) => {
     try {
-      setIdToken(id);
-
-      const response = await fetch(`${process.env.API_SERVER_URL}/api/google`, {
-        method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
+      const response = await fetch(
+        `${process.env.API_SERVER_URL}/api/auth/google`,
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            token: id,
+          }),
         },
-        body: JSON.stringify({
-          token: id,
-        }),
-      });
+      );
 
       const user = await response.json();
       setUser(user);
+      setIdToken(user.token);
 
       navigation.navigate("Home");
     } catch {

--- a/src/screen/VideoConcatScreen.jsx
+++ b/src/screen/VideoConcatScreen.jsx
@@ -5,13 +5,15 @@ import ModalSuccess from "../components/ModalSuccess";
 import { AntDesign } from "@expo/vector-icons";
 import { Fontisto } from "@expo/vector-icons";
 import * as VideoThumbnails from "expo-video-thumbnails";
+import { UserAuth } from "../context/AuthContext";
 
 function VideoConcatScreen({ route, navigation }) {
   const [success, setSuccess] = useState(false);
+  const [image, setImage] = useState(null);
+  const { idToken } = UserAuth();
+
   const { originVideo, liveVideo, galleryVideo } = route.params;
   const uri = liveVideo?.uri || galleryVideo?.uri;
-
-  const [image, setImage] = useState(null);
 
   useEffect(() => {
     generateThumbnail();
@@ -51,6 +53,7 @@ function VideoConcatScreen({ route, navigation }) {
         method: "PATCH",
         headers: {
           "Content-Type": "multipart/form-data",
+          Authorization: `Bearer ${idToken}`,
         },
         body: formdata,
       });

--- a/src/screen/VideoPostScreen.jsx
+++ b/src/screen/VideoPostScreen.jsx
@@ -11,12 +11,14 @@ import ModalError from "../components/ModalError";
 import ModalSuccess from "../components/ModalSuccess";
 import { Picker } from "@react-native-picker/picker";
 import { AntDesign } from "@expo/vector-icons";
+import { UserAuth } from "../context/AuthContext";
 
 function VideoPostScreen({ route, navigation }) {
   const [title, setTitle] = useState("");
   const [maxCreators, setMaxCreators] = useState(2);
   const [success, setSuccess] = useState(false);
   const { uri } = route.params;
+  const { idToken } = UserAuth();
 
   useEffect(() => {
     if (success) {
@@ -42,6 +44,7 @@ function VideoPostScreen({ route, navigation }) {
         method: "POST",
         headers: {
           "Content-Type": "multipart/form-data",
+          Authorization: `Bearer ${idToken}`,
         },
         body: formdata,
       });


### PR DESCRIPTION
## 주제
로그아웃 기능 추가, jwt token 저장 및 인가가 필요한 api 요청 헤더 추가

## 작업사항
1. 헤더에 로그아웃 기능 추가
2. 구글 id_token이 아닌 jwt token을 저장
3. 인가가 필요한 api 요청 헤더에 토큰 추가

### 변경사항
기존 구글 id_token을 저장하였으나, 백엔드에서 인가 프로세스가 변경되어 jwt token을 저장하는 방식으로 변경하였습니다.
이를 이용하여 추후 인가가 필요한 api 요청 시 헤더에 토큰을  담아 전달하게 됩니다!

추가로 헤더에 로그아웃 기능을 추가하였습니다.

## 기타
