### PR TITLE
[2022/06/16] 프로필 내 유저가 생성 및 참여한 비디오 리스트 렌더링

### DIFF
--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -1,20 +1,30 @@
 import { useEffect, useState } from "react";
 import { View, Image, FlatList, StyleSheet, Text } from "react-native";
 import { UserAuth } from "../context/AuthContext";
+import { useIsFocused } from "@react-navigation/native";
 
 import FeedItem from "./FeedItem";
 
 function Profile({ navigation }) {
-  const { user } = UserAuth();
+  const { user, idToken } = UserAuth();
   const [feeds, setFeeds] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
+  const isFocused = useIsFocused();
 
   const getData = async () => {
     setLoading(true);
 
     try {
-      const response = await fetch(`${process.env.API_SERVER_URL}/api/videos`);
+      const response = await fetch(
+        `${process.env.API_SERVER_URL}/api/videos/${user.userId}`,
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${idToken}`,
+          },
+        },
+      );
       const data = await response.json();
 
       if (data?.result === "ok") {
@@ -29,7 +39,7 @@ function Profile({ navigation }) {
 
   useEffect(() => {
     getData();
-  }, []);
+  }, [isFocused]);
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## 주제
프로필 내 유저가 생성 및 참여한 비디오 리스트 렌더링

## 작업사항
1. 유저 로그인 id 기준으로 백서버에 비디오 데이터 요청
2. 전달 받은 비디오 데이터 렌더링

### 변경사항
기존 전체 동영상을 렌더링 하는 것이 아닌 유저가 생성 및 참여한 비디오만 렌더링하도록 수정하였습니다. 

## 기타
현재 메인, 슬라이드 및 프로필에 불필요한 fetch 요청이 반복되는 것 같아
추후 전역적으로 데이터를 관리하는 방법으로 리팩토링이 필요할 것 같습니다. 

![image](https://user-images.githubusercontent.com/94096095/174035475-5ba5ce7a-00e2-4b7f-b1fc-dc617c1c8f1e.png)
