### PR TITLE
[2022/06/16]  FeedSlide 스와이핑 시 비디오 재생 안되는 에러 해결

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -13,7 +13,6 @@ import VideoConcatScreen from "./src/screen/VideoConcatScreen";
 import LoginScreen from "./src/screen/LoginScreen";
 import Profile from "./src/components/Profile";
 import EditGifScreen from "./src/screen/EditGifScreen";
-import FeedSlide from "./src/components/FeedSlide";
 
 const Stack = createNativeStackNavigator();
 
@@ -27,11 +26,6 @@ function App() {
             <Stack.Screen
               name="Home"
               component={TabNavigation}
-              options={{ headerShown: false }}
-            />
-            <Stack.Screen
-              name="Slide"
-              component={FeedSlide}
               options={{ headerShown: false }}
             />
             <Stack.Screen

--- a/App.jsx
+++ b/App.jsx
@@ -13,6 +13,7 @@ import VideoConcatScreen from "./src/screen/VideoConcatScreen";
 import LoginScreen from "./src/screen/LoginScreen";
 import Profile from "./src/components/Profile";
 import EditGifScreen from "./src/screen/EditGifScreen";
+import FeedSlide from "./src/components/FeedSlide";
 
 const Stack = createNativeStackNavigator();
 
@@ -26,6 +27,11 @@ function App() {
             <Stack.Screen
               name="Home"
               component={TabNavigation}
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="Slide"
+              component={FeedSlide}
               options={{ headerShown: false }}
             />
             <Stack.Screen

--- a/src/components/FeedSlideItem.jsx
+++ b/src/components/FeedSlideItem.jsx
@@ -1,10 +1,23 @@
 /* eslint-disable react/display-name */
-import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
-import { StyleSheet, View } from "react-native";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { Video } from "expo-av";
+import { AntDesign } from "@expo/vector-icons";
+import { Entypo } from "@expo/vector-icons";
+import { StatusBar } from "expo-status-bar";
+import { UserAuth } from "../context/AuthContext";
 
-const PostSingle = forwardRef(({ item }, parentRef) => {
-  const ref = useRef(null);
+export const FeedSlideItem = forwardRef(({ item, navigation }, parentRef) => {
+  const videoRef = useRef(null);
+  const [like, setLike] = useState(false);
+  const { idToken, user } = UserAuth();
+  const originVideo = item?.videoUrl;
 
   useImperativeHandle(parentRef, () => ({
     play,
@@ -16,75 +29,208 @@ const PostSingle = forwardRef(({ item }, parentRef) => {
     return () => unload();
   }, []);
 
+  useEffect(() => {
+    const unsubscribe = navigation.addListener("focus", () => {
+      if (videoRef) {
+        videoRef.current.playAsync();
+      }
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener("blur", () => {
+      if (videoRef) {
+        videoRef.current.pauseAsync();
+      }
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
   const play = async () => {
-    if (ref.current === null) {
+    if (videoRef.current === null) {
       return;
     }
 
-    const status = await ref.current.getStatusAsync();
+    const status = await videoRef.current.getStatusAsync();
 
     if (status?.isPlaying) {
       return;
     }
 
     try {
-      await ref.current.playAsync();
+      await videoRef.current.playAsync();
     } catch (err) {
       console.log(err);
     }
   };
 
   const stop = async () => {
-    if (ref.current === null) {
+    if (videoRef.current === null) {
       return;
     }
 
-    const status = await ref.current.getStatusAsync();
+    const status = await videoRef.current.getStatusAsync();
 
     if (!status?.isPlaying) {
       return;
     }
 
     try {
-      await ref.current.stopAsync();
+      await videoRef.current.stopAsync();
     } catch (err) {
       console.log(err);
     }
   };
 
   const unload = async () => {
-    if (ref.current === null) {
+    if (videoRef.current === null) {
       return;
     }
 
     try {
-      await ref.current.unloadAsync();
+      await videoRef.current.unloadAsync();
     } catch (err) {
       console.log(err);
     }
   };
 
+  const createGif = () => {
+    videoRef.current.pauseAsync();
+
+    if (idToken) {
+      console.log(originVideo);
+      navigation.navigate("Gif", { uri: originVideo });
+    } else {
+      navigation.navigate("Login");
+    }
+  };
+
+  const participateVideo = async () => {
+    videoRef.current.pauseAsync();
+
+    if (idToken) {
+      try {
+        navigation.navigate("Camera", { originVideo });
+      } catch (error) {
+        console.log(error);
+      }
+    } else {
+      navigation.navigate("Login");
+    }
+  };
+
   return (
     <View style={styles.container}>
+      <StatusBar backgroundColor="black" style="light" />
       <Video
-        ref={ref}
+        ref={videoRef}
         style={styles.video}
         resizeMode={"cover"}
-        shouldPlay={true}
         source={{ uri: item?.videoUrl }}
+        shouldPlay={false}
+        isLooping
+        usePoster
+        posterSource={{ uri: item?.thumbnails }}
       />
+      <View style={styles.headerContainer}>
+        <View style={styles.iconBox}>
+          <>
+            <TouchableOpacity
+              onPress={createGif}
+              style={styles.downloadGifIcon}
+            >
+              <AntDesign name="download" size={24} color="white" />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.downloadGifIcon}
+              onPress={() => setLike(!like)}
+            >
+              {like ? (
+                <Entypo name="heart" size={24} color="white" />
+              ) : (
+                <Entypo name="heart-outlined" size={24} color="white" />
+              )}
+            </TouchableOpacity>
+
+            <Text style={styles.gifText}>GIF</Text>
+          </>
+        </View>
+        <View style={styles.buttonBox}>
+          <TouchableOpacity onPress={participateVideo} style={styles.button}>
+            <Text style={styles.next}>
+              {originVideo ? "스토리 더하기" : "다음"}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+      <View style={styles.videoInfo}>
+        <Text style={{ color: "white", fontSize: 25 }}>{item.title}</Text>
+        <Image
+          style={styles.profile}
+          source={{
+            uri: user?.profilePhoto,
+          }}
+        />
+      </View>
     </View>
   );
 });
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    backgroundColor: "black",
   },
   video: {
     width: "100%",
     height: "100%",
+    backgroundColor: "black",
+  },
+  headerContainer: {
+    width: "100%",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    top: 10,
+    paddingHorizontal: 15,
+    position: "absolute",
+  },
+  iconBox: {
+    flexDirection: "row",
+  },
+  downloadGifIcon: {
+    paddingHorizontal: 15,
+  },
+  button: {
+    paddingHorizontal: 15,
+    paddingVertical: 5,
+    justifyContent: "center",
+    borderRadius: 5,
+    backgroundColor: "#FFF",
+  },
+  gifText: {
+    top: 25,
+    left: 18,
+    color: "white",
+    fontSize: 10,
+    position: "absolute",
+  },
+  videoInfo: {
+    position: "absolute",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    width: "100%",
+    bottom: 10,
+    paddingHorizontal: 15,
+  },
+  profile: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "white",
   },
 });
 
-export default PostSingle;
+export default FeedSlideItem;

--- a/src/components/FeedSlideItem.jsx
+++ b/src/components/FeedSlideItem.jsx
@@ -158,7 +158,7 @@ export const FeedSlideItem = forwardRef(({ item, navigation }, parentRef) => {
         </View>
         <View style={styles.buttonBox}>
           <TouchableOpacity onPress={participateVideo} style={styles.button}>
-            <Text style={styles.next}>{"스토리 더하기"}</Text>
+            <Text style={styles.next}>스토리 더하기</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/src/components/FeedSlideItem.jsx
+++ b/src/components/FeedSlideItem.jsx
@@ -17,7 +17,6 @@ export const FeedSlideItem = forwardRef(({ item, navigation }, parentRef) => {
   const videoRef = useRef(null);
   const [like, setLike] = useState(false);
   const { idToken, user } = UserAuth();
-  const originVideo = item?.videoUrl;
 
   useImperativeHandle(parentRef, () => ({
     play,
@@ -27,7 +26,7 @@ export const FeedSlideItem = forwardRef(({ item, navigation }, parentRef) => {
 
   useEffect(() => {
     return () => unload();
-  }, []);
+  }, [item]);
 
   useEffect(() => {
     const unsubscribe = navigation.addListener("focus", () => {
@@ -101,8 +100,7 @@ export const FeedSlideItem = forwardRef(({ item, navigation }, parentRef) => {
     videoRef.current.pauseAsync();
 
     if (idToken) {
-      console.log(originVideo);
-      navigation.navigate("Gif", { uri: originVideo });
+      navigation.navigate("Gif", { uri: item.videoUrl });
     } else {
       navigation.navigate("Login");
     }
@@ -113,7 +111,7 @@ export const FeedSlideItem = forwardRef(({ item, navigation }, parentRef) => {
 
     if (idToken) {
       try {
-        navigation.navigate("Camera", { originVideo });
+        navigation.navigate("Camera", { originVideo: item });
       } catch (error) {
         console.log(error);
       }
@@ -160,9 +158,7 @@ export const FeedSlideItem = forwardRef(({ item, navigation }, parentRef) => {
         </View>
         <View style={styles.buttonBox}>
           <TouchableOpacity onPress={participateVideo} style={styles.button}>
-            <Text style={styles.next}>
-              {originVideo ? "스토리 더하기" : "다음"}
-            </Text>
+            <Text style={styles.next}>{"스토리 더하기"}</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/src/screen/CameraScreen.jsx
+++ b/src/screen/CameraScreen.jsx
@@ -97,7 +97,12 @@ function CameraScreen({ navigation, route }) {
 
     if (!galleryVideo.cancelled) {
       originVideo
-        ? navigation.navigate("VideoConcat", { originVideo, galleryVideo })
+        ? navigation.navigate("VideoConcat", {
+            data: {
+              originVideo,
+              galleryVideo,
+            },
+          })
         : navigation.navigate("VideoResult", { galleryVideo });
     }
   };

--- a/src/screen/EditGifScreen.jsx
+++ b/src/screen/EditGifScreen.jsx
@@ -279,7 +279,7 @@ function EditGifScreen({ navigation, route }) {
           }}
         >
           {isLoading ? (
-            <ActivityIndicator size="large" color="black" />
+            <ActivityIndicator size="large" color="#2196F3" />
           ) : (
             <TouchableOpacity
               onPress={gifUrl ? saveGif : convertVideoToGif}

--- a/src/screen/VideoConcatScreen.jsx
+++ b/src/screen/VideoConcatScreen.jsx
@@ -89,7 +89,7 @@ function VideoConcatScreen({ route, navigation }) {
           }}
         >
           {isLoading ? (
-            <ActivityIndicator size="large" color="black" />
+            <ActivityIndicator size="large" color="#2196F3" />
           ) : (
             <TouchableOpacity onPress={concatVideo} style={styles.concatButton}>
               <Text style={styles.concatText}>합치기</Text>

--- a/src/screen/VideoResultScreen.jsx
+++ b/src/screen/VideoResultScreen.jsx
@@ -96,9 +96,7 @@ function VideoResultScreen({ route, navigation }) {
               <Text style={styles.gifText}>GIF</Text>
             </>
           ) : (
-            <View style={styles.buttonBox}>
-              <Text style={styles.start}>Vistel 시작하기</Text>
-            </View>
+            <></>
           )}
         </View>
         <View style={styles.buttonBox}>


### PR DESCRIPTION
## 주제
FeedSlide 스와이핑 시 비디오 재생 안되는 현상 해결

### 작업사항
- FeedSlide mediaRef.current의 index를 element(객체)에서 element.index(숫자)로 변경
- FeedSlide에서 FeedSlideItem으로 넘겨주는 ref값을 받는 mediaRef.current의 index를 위와 동일하게 변경
- 비디오 리스트 받기 전까지 로딩 추가 / 리스트 받으면 로딩 종료
- 비디오가 다 받아지기 전까지 비디오 썸네일로 대체하열 빈 공백 해결
- 다른 컴포넌트 로딩 색깔 및 변수명 변경

### 기타
- 슬라이딩 화면에서 다른 페이지 이동 후 다시 돌아올 경우 해당 슬라이드에 없는 동영상 재생 현상 발생
