### PR TITLE
[2022/08/09] 네비게이션 Screen 공통 옵션 사항 적용, Auth 및 Modal 관련 useReducer 추가

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,72 +1,16 @@
-import { StatusBar } from "expo-status-bar";
-import { NavigationContainer } from "@react-navigation/native";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { AuthContextProvider } from "./src/context/AuthContext";
 import { ModalContextProvider } from "./src/context/modalContext";
 import { NativeBaseProvider } from "native-base";
 import "react-native-gesture-handler";
 
-import TabNavigation from "./src/navigation/TabNavigation";
-import CameraScreen from "./src/screen/CameraScreen";
-import VideoResultScreen from "./src/screen/VideoResultScreen";
-import VideoPostScreen from "./src/screen/VideoPostScreen";
-import VideoConcatScreen from "./src/screen/VideoConcatScreen";
-import LoginScreen from "./src/screen/LoginScreen";
-import ProfileScreen from "./src/screen/ProfileScreen";
-import EditGifScreen from "./src/screen/EditGifScreen";
-
-const Stack = createNativeStackNavigator();
+import MainNavigation from "./src/navigation/MainNavigation";
 
 function App() {
   return (
     <AuthContextProvider>
       <ModalContextProvider>
         <NativeBaseProvider>
-          <NavigationContainer>
-            <StatusBar style="auto" />
-            <Stack.Navigator initialRouteName="Home">
-              <Stack.Screen
-                name="Home"
-                component={TabNavigation}
-                options={{ headerShown: false }}
-              />
-              <Stack.Screen
-                name="Camera"
-                component={CameraScreen}
-                options={{ headerShown: false }}
-              />
-              <Stack.Screen
-                name="Login"
-                component={LoginScreen}
-                options={{ headerShown: false }}
-              />
-              <Stack.Screen
-                name="VideoResult"
-                component={VideoResultScreen}
-                options={{ headerShown: false }}
-              />
-              <Stack.Screen
-                name="VideoPost"
-                component={VideoPostScreen}
-                options={{ headerShown: false }}
-              />
-              <Stack.Screen
-                name="VideoConcat"
-                component={VideoConcatScreen}
-                options={{ headerShown: false }}
-              />
-              <Stack.Screen
-                name="Gif"
-                component={EditGifScreen}
-                options={{ headerShown: false }}
-              />
-              <Stack.Screen
-                name="Profile"
-                component={ProfileScreen}
-                options={{ headerShown: false }}
-              />
-            </Stack.Navigator>
-          </NavigationContainer>
+          <MainNavigation />
         </NativeBaseProvider>
       </ModalContextProvider>
     </AuthContextProvider>

--- a/src/components/shared/header.jsx
+++ b/src/components/shared/header.jsx
@@ -2,16 +2,16 @@ import React from "react";
 import { View, Text, StyleSheet, TouchableOpacity, Image } from "react-native";
 import vistelLogo from "../../../assets/vistel-logo.png";
 
-import { UserAuth } from "../../context/AuthContext";
+import { UserAuth, UserAuthDispatch } from "../../context/AuthContext";
 import { LOGIN, LOGOUT } from "../../../constants/text";
 
 function AppHeader({ navigation }) {
-  const { user, setUser, setIdToken } = UserAuth();
+  const { user } = UserAuth();
+  const authDispatch = UserAuthDispatch();
 
   const handleLogin = () => navigation.navigate("Login");
   const handleLogout = () => {
-    setUser("");
-    setIdToken("");
+    authDispatch({ type: "SIGN_OUT" });
 
     navigation.reset({ index: 0, routes: [{ name: "Home" }] });
   };

--- a/src/components/shared/modal.jsx
+++ b/src/components/shared/modal.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Center, Modal, Button } from "native-base";
-import { ModalHandler } from "../../context/modalContext";
+import { ModalHandler, ModalDispatchHandler } from "../../context/modalContext";
 
 function ModalContainer({
   navigation,
@@ -8,13 +8,14 @@ function ModalContainer({
   modalHeader,
   modalBody,
 }) {
-  const { openModal, setOpenModal } = ModalHandler();
+  const modalStatus = ModalHandler();
+  const { handleModalClose } = ModalDispatchHandler();
 
   return (
     <Center>
       <Modal
-        isOpen={openModal}
-        onClose={() => setOpenModal(false)}
+        isOpen={modalStatus}
+        onClose={handleModalClose}
         _backdrop={{
           _dark: {
             bg: "coolGray.800",
@@ -28,7 +29,7 @@ function ModalContainer({
           <Modal.Footer>
             <Button
               onPress={() => {
-                setOpenModal(false);
+                handleModalClose();
 
                 if (isRequiredToGoBack) {
                   navigation.goBack();

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,14 +1,40 @@
-import { useContext, createContext, useState } from "react";
+import { useContext, createContext, useReducer } from "react";
 
+const initialState = {
+  user: null,
+  idToken: "",
+};
 const AuthContext = createContext();
+const AuthDispatchContext = createContext();
+
+const reducer = (preState, action) => {
+  switch (action.type) {
+    case "SIGN_IN":
+      return {
+        ...preState,
+        user: action.user,
+        idToken: action.idToken,
+      };
+    case "SIGN_OUT":
+      return {
+        ...preState,
+        user: null,
+        idToken: "",
+      };
+    default:
+      throw new Error(`Unhandled action type: ${action.type}`);
+  }
+};
 
 export function AuthContextProvider({ children }) {
-  const [user, setUser] = useState(null);
-  const [idToken, setIdToken] = useState(null);
+  const [authInfo, authDispatch] = useReducer(reducer, initialState);
+  const { user, idToken } = authInfo;
 
   return (
-    <AuthContext.Provider value={{ user, setUser, idToken, setIdToken }}>
-      {children}
+    <AuthContext.Provider value={{ user, idToken }}>
+      <AuthDispatchContext.Provider value={authDispatch}>
+        {children}
+      </AuthDispatchContext.Provider>
     </AuthContext.Provider>
   );
 }
@@ -16,3 +42,7 @@ export function AuthContextProvider({ children }) {
 export const UserAuth = () => {
   return useContext(AuthContext);
 };
+
+export function UserAuthDispatch() {
+  return useContext(AuthDispatchContext);
+}

--- a/src/context/modalContext.jsx
+++ b/src/context/modalContext.jsx
@@ -1,17 +1,46 @@
-import { useContext, createContext, useState } from "react";
+import { useContext, createContext, useReducer } from "react";
 
 const ModalContext = createContext();
+const ModalDispatchContext = createContext();
+
+const initialState = false;
+
+const reducer = (preState, action) => {
+  switch (action.type) {
+    case "OPEN_MODAL":
+      return true;
+    case "CLOSE_MODAL":
+      return false;
+    default:
+      throw new Error(`Unhandled action type: ${action.type}`);
+  }
+};
 
 export function ModalContextProvider({ children }) {
-  const [openModal, setOpenModal] = useState(false);
+  const [modalStatus, modalDispatch] = useReducer(reducer, initialState);
+
+  const handleModalOpen = () => {
+    modalDispatch({ type: "OPEN_MODAL" });
+  };
+  const handleModalClose = () => {
+    modalDispatch({ type: "CLOSE_MODAL" });
+  };
 
   return (
-    <ModalContext.Provider value={{ openModal, setOpenModal }}>
-      {children}
+    <ModalContext.Provider value={modalStatus}>
+      <ModalDispatchContext.Provider
+        value={{ handleModalOpen, handleModalClose }}
+      >
+        {children}
+      </ModalDispatchContext.Provider>
     </ModalContext.Provider>
   );
 }
 
 export const ModalHandler = () => {
   return useContext(ModalContext);
+};
+
+export const ModalDispatchHandler = () => {
+  return useContext(ModalDispatchContext);
 };

--- a/src/navigation/MainNavigation.jsx
+++ b/src/navigation/MainNavigation.jsx
@@ -1,0 +1,47 @@
+import { StatusBar } from "expo-status-bar";
+import { NavigationContainer } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import "react-native-gesture-handler";
+
+import { UserAuth } from "../context/AuthContext";
+
+import TabNavigation from "./TabNavigation";
+import CameraScreen from "../screen/CameraScreen";
+import VideoResultScreen from "../screen/VideoResultScreen";
+import VideoPostScreen from "../screen/VideoPostScreen";
+import VideoConcatScreen from "../screen/VideoConcatScreen";
+import LoginScreen from "../screen/LoginScreen";
+import ProfileScreen from "../screen/ProfileScreen";
+import EditGifScreen from "../screen/EditGifScreen";
+
+const Stack = createNativeStackNavigator();
+
+function MainNavigation() {
+  const { idToken } = UserAuth();
+
+  return (
+    <NavigationContainer>
+      <StatusBar style="auto" />
+      <Stack.Navigator
+        initialRouteName="Home"
+        screenOptions={{ headerShown: false }}
+      >
+        <Stack.Screen name="Home" component={TabNavigation} />
+        {idToken ? (
+          <>
+            <Stack.Screen name="Camera" component={CameraScreen} />
+            <Stack.Screen name="VideoResult" component={VideoResultScreen} />
+            <Stack.Screen name="VideoPost" component={VideoPostScreen} />
+            <Stack.Screen name="VideoConcat" component={VideoConcatScreen} />
+            <Stack.Screen name="Gif" component={EditGifScreen} />
+            <Stack.Screen name="Profile" component={ProfileScreen} />
+          </>
+        ) : (
+          <Stack.Screen name="Login" component={LoginScreen} />
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+export default MainNavigation;

--- a/src/navigation/TabNavigation.jsx
+++ b/src/navigation/TabNavigation.jsx
@@ -5,6 +5,8 @@ import { UserAuth } from "../context/AuthContext";
 import MainFeedScreen from "../screen/MainFeedScreen";
 import SearchScreen from "../screen/SearchScreen";
 import FeedSlideScreen from "../screen/FeedSlideScreen";
+import ProfileScreen from "../screen/ProfileScreen";
+import CameraScreen from "../screen/CameraScreen";
 import AppHeader from "../components/shared/header";
 
 import { AntDesign, Feather, Entypo, FontAwesome } from "@expo/vector-icons";
@@ -47,7 +49,7 @@ function TabNavigation({ navigation }) {
       />
       <Tab.Screen
         name="Record"
-        component={EmptyScreen}
+        component={CameraScreen}
         listeners={({ navigation }) => ({
           tabPress: (event) => {
             event.preventDefault();
@@ -76,7 +78,7 @@ function TabNavigation({ navigation }) {
       />
       <Tab.Screen
         name="Profile"
-        component={EmptyScreen}
+        component={ProfileScreen}
         listeners={({ navigation }) => ({
           tabPress: (event) => {
             event.preventDefault();

--- a/src/navigation/TabNavigation.jsx
+++ b/src/navigation/TabNavigation.jsx
@@ -4,7 +4,6 @@ import { UserAuth } from "../context/AuthContext";
 
 import MainFeedScreen from "../screen/MainFeedScreen";
 import SearchScreen from "../screen/SearchScreen";
-import Profile from "../screen/ProfileScreen";
 import FeedSlideScreen from "../screen/FeedSlideScreen";
 import AppHeader from "../components/shared/header";
 
@@ -18,13 +17,15 @@ const Tab = createBottomTabNavigator();
 
 function TabNavigation({ navigation }) {
   const { idToken, user } = UserAuth();
+
   return (
-    <Tab.Navigator>
+    <Tab.Navigator
+      screenOptions={{ tabBarShowLabel: false, tabBarStyle: { height: 50 } }}
+    >
       <Tab.Screen
         name="Feed"
         component={MainFeedScreen}
         options={{
-          tabBarShowLabel: false,
           tabBarIcon: ({ color }) => (
             <Entypo name="home" size={25} color={color} />
           ),
@@ -32,19 +33,16 @@ function TabNavigation({ navigation }) {
           headerStyle: {
             backgroundColor: "black",
           },
-          tabBarStyle: { height: 50 },
         }}
       />
       <Tab.Screen
         name="Slide"
         component={FeedSlideScreen}
         options={{
-          tabBarShowLabel: false,
           tabBarIcon: ({ color }) => (
             <FontAwesome name="list" size={25} color={color} />
           ),
           header: () => null,
-          tabBarStyle: { height: 50 },
         }}
       />
       <Tab.Screen
@@ -60,28 +58,25 @@ function TabNavigation({ navigation }) {
           },
         })}
         options={{
-          tabBarShowLabel: false,
           tabBarIcon: ({ color }) => (
             <AntDesign name="pluscircleo" size={35} color={color} />
           ),
-          tabBarStyle: { height: 50 },
+          header: () => null,
         }}
       />
       <Tab.Screen
         name="Search"
         component={SearchScreen}
         options={{
-          tabBarShowLabel: false,
           tabBarIcon: ({ color }) => (
             <AntDesign name="search1" size={25} color={color} />
           ),
           header: () => <AppHeader navigation={navigation} />,
-          tabBarStyle: { height: 50 },
         }}
       />
       <Tab.Screen
         name="Profile"
-        component={Profile}
+        component={EmptyScreen}
         listeners={({ navigation }) => ({
           tabPress: (event) => {
             event.preventDefault();
@@ -92,7 +87,6 @@ function TabNavigation({ navigation }) {
           },
         })}
         options={{
-          tabBarShowLabel: false,
           tabBarIcon: ({ color }) => {
             return user ? (
               <Image
@@ -106,7 +100,6 @@ function TabNavigation({ navigation }) {
             );
           },
           header: () => <AppHeader navigation={navigation} />,
-          tabBarStyle: { height: 50 },
         }}
       />
     </Tab.Navigator>

--- a/src/screen/CameraScreen.jsx
+++ b/src/screen/CameraScreen.jsx
@@ -6,7 +6,7 @@ import * as MediaLibrary from "expo-media-library";
 import { useIsFocused } from "@react-navigation/core";
 import { Feather } from "@expo/vector-icons";
 
-import { ModalHandler } from "../context/modalContext";
+import { ModalHandler, ModalDispatchHandler } from "../context/modalContext";
 import ModalContainer from "../components/shared/modal";
 import { PERMISSION_GRANTED } from "../../constants/text";
 import {
@@ -25,8 +25,8 @@ function CameraScreen({ navigation, route }) {
     Camera.Constants.FlashMode.off,
   );
   const originVideo = route?.params?.originVideo;
-  const { openModal, setOpenModal } = ModalHandler();
-
+  const modalStatus = ModalHandler();
+  const { handleModalOpen } = ModalDispatchHandler();
   const [galleryItems, setGalleryItems] = useState([]);
   const [isCameraReady, setIsCameraReady] = useState(false);
   const isFocused = useIsFocused();
@@ -90,7 +90,7 @@ function CameraScreen({ navigation, route }) {
             : navigation.navigate("VideoResult", { liveVideo });
         }
       } catch (error) {
-        setOpenModal(true);
+        handleModalOpen();
       }
     }
   };
@@ -188,7 +188,7 @@ function CameraScreen({ navigation, route }) {
           </View>
         )}
       </View>
-      {openModal && (
+      {modalStatus && (
         <ModalContainer
           modalHeader={errorMessage.ERROR}
           modalBody={errorMessage.ERROR_RECORD_VIDEO}

--- a/src/screen/EditGifScreen.jsx
+++ b/src/screen/EditGifScreen.jsx
@@ -17,7 +17,7 @@ import ModalContainer from "../components/shared/modal";
 import OptionList from "../components/OptionList";
 import Loading from "../components/shared/loading";
 
-import { ModalHandler } from "../context/modalContext";
+import { ModalHandler, ModalDispatchHandler } from "../context/modalContext";
 import { UserAuth } from "../context/AuthContext";
 import { convertGif } from "../api/index";
 import {
@@ -46,7 +46,8 @@ function EditGifScreen({ navigation, route }) {
   const [filter, setFilter] = useState(defalutGifFilterValue);
   const [downloading, setDownloading] = useState(false);
 
-  const { openModal, setOpenModal } = ModalHandler();
+  const modalStatus = ModalHandler();
+  const { handleModalOpen } = ModalDispatchHandler();
   const { idToken } = UserAuth();
 
   const showToastMessage = () => {
@@ -64,13 +65,13 @@ function EditGifScreen({ navigation, route }) {
       const data = await convertGif(idToken, uri, filter);
 
       if (data.result === fetchResult.FAILURE) {
-        setOpenModal(true);
+        handleModalOpen();
         return;
       }
 
       setGifUrl(data.file);
     } catch (error) {
-      setOpenModal(true);
+      handleModalOpen();
     }
 
     setIsLoading(false);
@@ -104,7 +105,7 @@ function EditGifScreen({ navigation, route }) {
 
       navigation.goBack();
     } catch (error) {
-      setOpenModal(true);
+      handleModalOpen();
       setDownloading(true);
     }
   };
@@ -181,7 +182,7 @@ function EditGifScreen({ navigation, route }) {
           )}
         </View>
       </View>
-      {openModal && (
+      {modalStatus && (
         <ModalContainer
           isRequiredToGoBack={true}
           navigation={navigation}

--- a/src/screen/FeedSlideScreen.jsx
+++ b/src/screen/FeedSlideScreen.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { View, StyleSheet } from "react-native";
 
-import { ModalHandler } from "../context/modalContext";
+import { ModalHandler, ModalDispatchHandler } from "../context/modalContext";
 import { getVideoList } from "../api";
 
 import FeedSlide from "../components/FeedSlide";
@@ -12,7 +12,8 @@ import { errorMessage, fetchResult } from "../../constants/index";
 function FeedSlideScreen({ navigation }) {
   const [feed, setFeed] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
-  const { openModal, setOpenModal } = ModalHandler();
+  const modalStatus = ModalHandler();
+  const { handleModalOpen } = ModalDispatchHandler();
 
   const getFeed = async () => {
     setIsLoading(true);
@@ -24,7 +25,7 @@ function FeedSlideScreen({ navigation }) {
         setFeed([...data?.videoList]);
       }
     } catch (error) {
-      setOpenModal(true);
+      handleModalOpen();
     }
 
     setIsLoading(false);
@@ -43,7 +44,7 @@ function FeedSlideScreen({ navigation }) {
       ) : (
         <FeedSlide videoList={feed} navigation={navigation} />
       )}
-      {openModal && (
+      {modalStatus && (
         <ModalContainer
           modalHeader={errorMessage.ERROR}
           modalBody={errorMessage.ERROR_VIDEOLIST}

--- a/src/screen/LoginScreen.jsx
+++ b/src/screen/LoginScreen.jsx
@@ -10,8 +10,8 @@ import { StatusBar } from "expo-status-bar";
 import * as Google from "expo-auth-session/providers/google";
 import * as WebBrowser from "expo-web-browser";
 
-import { UserAuth } from "../context/AuthContext";
-import { ModalHandler } from "../context/modalContext";
+import { UserAuthDispatch } from "../context/AuthContext";
+import { ModalHandler, ModalDispatchHandler } from "../context/modalContext";
 import { loginGoogle } from "../api/index";
 
 import ModalContainer from "../components/shared/modal";
@@ -24,8 +24,9 @@ WebBrowser.maybeCompleteAuthSession();
 LogBox.ignoreLogs(["EventEmitter.removeListener"]);
 
 function LoginScreen({ navigation }) {
-  const { setUser, setIdToken } = UserAuth();
-  const { openModal, setOpenModal } = ModalHandler();
+  const authDispatch = UserAuthDispatch();
+  const modalStatus = ModalHandler();
+  const { handleModalOpen } = ModalDispatchHandler();
 
   const [request, response, promptAsync] = Google.useAuthRequest({
     expoClientId: process.env.EXPO_CLIENT_ID,
@@ -41,12 +42,10 @@ function LoginScreen({ navigation }) {
     try {
       const user = await loginGoogle(id);
 
-      setUser(user);
-      setIdToken(user.token);
-
+      authDispatch({ type: "SIGN_IN", payload: { user, idToken: user.token } });
       navigation.goBack();
     } catch {
-      setOpenModal(true);
+      handleModalOpen();
     }
   };
 
@@ -69,7 +68,7 @@ function LoginScreen({ navigation }) {
             />
           </TouchableOpacity>
         </View>
-        {openModal && (
+        {modalStatus && (
           <ModalContainer
             isRequiredToGoBack={true}
             navigation={navigation}

--- a/src/screen/MainFeedScreen.jsx
+++ b/src/screen/MainFeedScreen.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { View, FlatList, StyleSheet } from "react-native";
 import { useIsFocused } from "@react-navigation/native";
 
-import { ModalHandler } from "../context/modalContext";
+import { ModalHandler, ModalDispatchHandler } from "../context/modalContext";
 import { getVideoList } from "../api/index";
 
 import FeedItem from "../components/FeedItem";
@@ -12,7 +12,8 @@ import { fetchResult, errorMessage } from "../../constants/index";
 function MainFeedScreen({ navigation }) {
   const [feeds, setFeeds] = useState([]);
   const [loading, setLoading] = useState(false);
-  const { openModal, setOpenModal } = ModalHandler();
+  const modalStatus = ModalHandler();
+  const { handleModalOpen } = ModalDispatchHandler();
   const isFocused = useIsFocused();
 
   const getData = async () => {
@@ -25,7 +26,7 @@ function MainFeedScreen({ navigation }) {
         setFeeds([...data?.videoList]);
       }
     } catch (error) {
-      setOpenModal(true);
+      handleModalOpen();
     }
 
     setLoading(false);
@@ -49,7 +50,7 @@ function MainFeedScreen({ navigation }) {
           )}
         />
       </View>
-      {openModal && (
+      {modalStatus && (
         <ModalContainer
           modalHeader={errorMessage.ERROR}
           modalBody={errorMessage.ERROR_VIDEOLIST}

--- a/src/screen/ProfileScreen.jsx
+++ b/src/screen/ProfileScreen.jsx
@@ -3,7 +3,7 @@ import { View, Image, FlatList, StyleSheet, Text } from "react-native";
 import { useIsFocused } from "@react-navigation/native";
 
 import { UserAuth } from "../context/AuthContext";
-import { ModalHandler } from "../context/modalContext";
+import { ModalHandler, ModalDispatchHandler } from "../context/modalContext";
 import { getUserInfo } from "../api/index";
 
 import FeedItem from "../components/FeedItem";
@@ -14,7 +14,8 @@ function ProfileScreen({ navigation }) {
   const { user, idToken } = UserAuth();
   const [feeds, setFeeds] = useState([]);
   const [loading, setLoading] = useState(false);
-  const { openModal, setOpenModal } = ModalHandler();
+  const modalStatus = ModalHandler();
+  const { handleModalOpen } = ModalDispatchHandler();
   const isFocused = useIsFocused();
 
   const getData = async () => {
@@ -27,7 +28,7 @@ function ProfileScreen({ navigation }) {
         setFeeds([...data?.videoList]);
       }
     } catch (error) {
-      setOpenModal(true);
+      handleModalOpen();
     }
 
     setLoading(false);
@@ -60,7 +61,7 @@ function ProfileScreen({ navigation }) {
           )}
         />
       </View>
-      {openModal && (
+      {modalStatus && (
         <ModalContainer
           modalHeader={errorMessage.ERROR}
           modalBody={errorMessage.ERROR_VIDEOLIST}

--- a/src/screen/SearchScreen.jsx
+++ b/src/screen/SearchScreen.jsx
@@ -4,7 +4,7 @@ import { useIsFocused } from "@react-navigation/native";
 
 import { getVideoList } from "../api/index";
 import { fetchResult, errorMessage } from "../../constants/index";
-import { ModalHandler } from "../context/modalContext";
+import { ModalHandler, ModalDispatchHandler } from "../context/modalContext";
 
 import FeedItem from "../components/FeedItem";
 import ModalContainer from "../components/shared/modal";
@@ -14,7 +14,8 @@ function SearchScreen({ navigation }) {
   const [filtered, setFiltered] = useState([]);
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(false);
-  const { openModal, setOpenModal } = ModalHandler();
+  const modalStatus = ModalHandler();
+  const { handleModalOpen } = ModalDispatchHandler();
   const isFocused = useIsFocused();
 
   const getData = async () => {
@@ -27,7 +28,7 @@ function SearchScreen({ navigation }) {
         setVideos([...data?.videoList]);
       }
     } catch (error) {
-      setOpenModal(true);
+      handleModalOpen();
     }
 
     setLoading(false);
@@ -75,7 +76,7 @@ function SearchScreen({ navigation }) {
           />
         </View>
       </View>
-      {openModal && (
+      {modalStatus && (
         <ModalContainer
           modalHeader={errorMessage.ERROR}
           modalBody={errorMessage.ERROR_VIDEOLIST}

--- a/src/screen/VideoConcatScreen.jsx
+++ b/src/screen/VideoConcatScreen.jsx
@@ -3,7 +3,7 @@ import { Text, View, StyleSheet, Image, TouchableOpacity } from "react-native";
 import { AntDesign, Fontisto } from "@expo/vector-icons";
 
 import { UserAuth } from "../context/AuthContext";
-import { ModalHandler } from "../context/modalContext";
+import { ModalHandler, ModalDispatchHandler } from "../context/modalContext";
 import { concatVideos } from "../api/index";
 
 import ModalContainer from "../components/shared/modal";
@@ -15,7 +15,8 @@ function VideoConcatScreen({ route, navigation }) {
   const [isLoading, setIsLoading] = useState(false);
 
   const { idToken } = UserAuth();
-  const { openModal, setOpenModal } = ModalHandler();
+  const modalStatus = ModalHandler();
+  const { handleModalOpen } = ModalDispatchHandler();
 
   const { originVideo, liveVideo, galleryVideo } = route.params.data;
   const uri = liveVideo?.uri || galleryVideo?.uri;
@@ -40,7 +41,7 @@ function VideoConcatScreen({ route, navigation }) {
         setSuccess(true);
       }
     } catch (error) {
-      setOpenModal(true);
+      handleModalOpen();
     }
 
     setIsLoading(false);
@@ -87,7 +88,7 @@ function VideoConcatScreen({ route, navigation }) {
           )}
         </View>
       </View>
-      {openModal && (
+      {modalStatus && (
         <ModalContainer
           isRequiredToGoBack={true}
           navigation={navigation}

--- a/src/screen/VideoPostScreen.jsx
+++ b/src/screen/VideoPostScreen.jsx
@@ -12,7 +12,7 @@ import { AntDesign } from "@expo/vector-icons";
 import { StatusBar } from "expo-status-bar";
 
 import { UserAuth } from "../context/AuthContext";
-import { ModalHandler } from "../context/modalContext";
+import { ModalHandler, ModalDispatchHandler } from "../context/modalContext";
 import { postVideo } from "../api/index";
 
 import ModalContainer from "../components/shared/modal";
@@ -28,7 +28,8 @@ function VideoPostScreen({ route, navigation }) {
   const [isLoading, setIsLoading] = useState(false);
   const { uri, thumbnail } = route.params;
   const { idToken } = UserAuth();
-  const { openModal, setOpenModal } = ModalHandler();
+  const modalStatus = ModalHandler();
+  const { handleModalOpen } = ModalDispatchHandler();
 
   const uploadVideo = async () => {
     setIsLoading(true);
@@ -48,7 +49,7 @@ function VideoPostScreen({ route, navigation }) {
     };
 
     if (!post.title) {
-      setOpenModal(true);
+      handleModalOpen();
       return;
     }
 
@@ -66,7 +67,7 @@ function VideoPostScreen({ route, navigation }) {
       }
     } catch {
       setIsLoading(false);
-      setOpenModal(true);
+      handleModalOpen();
     }
   };
 
@@ -120,7 +121,7 @@ function VideoPostScreen({ route, navigation }) {
           )}
         </TouchableOpacity>
       </View>
-      {openModal && (
+      {modalStatus && (
         <ModalContainer
           isRequiredToGoBack={true}
           navigation={navigation}


### PR DESCRIPTION
## 주제
* 네비게이션 Screen 관련 공통 옵션 사항 분리 적용
* Auth 기준으로 Stack Screen 분리
* Auth 및 Modal 관련 useReducer 추가

### 변경사항
**1. 네비게이션 Screen 관련 공통 옵션 사항 분리 적용**
불필요한 Screen 관련 공통 옵션을 한 번에 적용할 수 있도록 수정하였습니다.
아래와 같이 headerShown에 대한 옵션이 기존에는 모든 스크린에 추가되어 있었는데, 공통 옵션으로 분리하여 불필요한 중복을 제거하였습니다. 

![image](https://user-images.githubusercontent.com/94096095/183455442-5c2fb413-493b-40c5-b1e1-04fb7b86d56c.png)

**2. Auth 기준으로 Stack Screen 분리**
공식 사이트를 살펴보던 도중 Authentication 관련한 글이 있어 살펴보니,
token 변수 값 기준으로 스택 스크린을 분리할 수 있으며,
별다른 네비게이션 필요없이 token 여부에 따라 스크린을 알아서 변경해준다고 합니다. 

글을 참고하여 수정해 보았으니 테스트 부탁 드립니다. 

```javascript
<>
  {isSignedIn ? (
    <>
      <Stack.Screen name="Home" component={HomeScreen} />
      <Stack.Screen name="Profile" component={ProfileScreen} />
    </>
  ) : (
    <>
      <Stack.Screen name="SignIn" component={SignInScreen} />
      <Stack.Screen name="SignUp" component={SignUpScreen} />
    </>
  )}
  <Stack.Screen navigationKey={isSignedIn ? 'user' : 'guest'} name="Help" component={HelpScreen} />
</>
```

[네비게이션 Authentication flows](https://reactnavigation.org/docs/auth-flow)

**3. Auth 및 Modal 관련 useReducer 추가**
기존 useContext만 사용하였던 Auth 및 Modal 로직에 useReducer을 추가하여
수정하였습니다.

dispatch용 컨텍스트를 별도로 구성하여 필요한 컴포넌트에 호출하여 사용할 수 있습니다.

[useCallback 및 useReducer 참고
](https://velog.io/@shin6403/useContextuseReducer%EB%A1%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)